### PR TITLE
fix(ApifulServiceProvider): removed vendor publish

### DIFF
--- a/src/ApifulServiceProvider.php
+++ b/src/ApifulServiceProvider.php
@@ -47,8 +47,6 @@ class ApifulServiceProvider extends ServiceProvider
             return apiful($data);
         });
 
-        Artisan::call("vendor:publish --tag='apiful-config'");
-
     }
 
     protected function registerPublishing()


### PR DESCRIPTION
This command interferes with other packages and should just be part of the install instructions.

I have multiple projects now where other package commands are "not defined" after installing this package, and removing this line resolves the problem.